### PR TITLE
Add ConstrainedBackTrackingSolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ A full historical list of bench mark results can be found at [bench_results.md](
 ### Latest
 Name | [fastest, median, slowest]
 --- | --- 
-Backtracking_simple | [0.61058 ms 0.61940 ms 0.62912 ms]
-Backtracking_hard | [1849.1 ms 1888.0 ms 1934.6 ms]
+Backtracking_simple | [0.61103 ms 0.61214 ms 0.61343 ms]
+Backtracking_hard | [1844.7 ms 1854.6 ms 1864.9 ms]
+ConstrainedBackTrackingSolver_simple | [0.20164 ms 0.20315 ms 0.20513]
+ConstrainedBackTrackingSolver_hard | [1041.0 ms 1048.3 ms 1057.2 ms]
+
 
 ### Usage
 ```bash

--- a/benches/bench_results.md
+++ b/benches/bench_results.md
@@ -1,3 +1,9 @@
+### 2025-08-19
+- **Backtracking_simple**: [0.61103 ms 0.61214 ms 0.61343 ms]
+- **Backtracking_hard**: [1844.7 ms 1854.6 ms 1864.9 ms]
+- **ConstrainedBackTrackingSolver_simple**: [0.20164 ms 0.20315 ms 0.20513 ms]
+- **ConstrainedBackTrackingSolver_hard**: [1041.0 ms 1048.3 ms 1057.2 ms]
+
 ### 2025-08-18 (2)
 - **Backtracking_simple**: [0.61058 ms 0.61940 ms 0.62912 ms]
 - **Backtracking_hard**: [1849.1 ms 1888.0 ms 1934.6 ms]

--- a/benches/solvers.rs
+++ b/benches/solvers.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use criterion::{
     BenchmarkGroup, Criterion, criterion_group, criterion_main, measurement::WallTime,
 };
-use rust_sudoku_solver::solvers::{Solver, backtracking::BackTrackingSolver};
+use rust_sudoku_solver::solvers::{backtracking::BackTrackingSolver, constrained_backtracking::ConstrainedBackTrackingSolver, Solver};
 
 fn bench_solvers(c: &mut Criterion) {
     let mut group = c.benchmark_group("sudoku_solvers");
@@ -34,6 +34,7 @@ fn bench_all_solvers(
 ) {
     let solvers: &[Box<dyn Solver>] = &[
         Box::new(BackTrackingSolver),
+        Box::new(ConstrainedBackTrackingSolver)
     ];
     
     for solver in solvers {

--- a/src/board/cell/constrained_cell.rs
+++ b/src/board/cell/constrained_cell.rs
@@ -1,0 +1,100 @@
+use crate::board::cell::{CellPosition, CellValue, IncrementResult, IsCell};
+
+#[derive(Copy, Clone, PartialEq)]
+pub enum ValueConstraint {
+    Allowed,
+    FixedNotAllowed,
+}
+
+#[derive(Clone, PartialEq)]
+pub struct ConstrainedCell {
+    pub value: CellValue,
+    pub fixed: bool,
+    pub position: CellPosition,
+    // pos 0 is ignored to reduce number of +1s
+    pub value_constraint_map: [ValueConstraint; 10],
+}
+
+impl ConstrainedCell {
+    pub fn increment(&mut self) -> IncrementResult {
+        match self.value {
+            CellValue::Empty => match self.get_next_not_constrained(1) {
+                // Can't be incremented, set to empty and tell the backtracker to find a new cell
+                None => {
+                    self.value = CellValue::Empty;
+                    IncrementResult {
+                        is_board_valid: false,
+                        needs_revalidation: false,
+                    }
+                }
+                // There is at least 1 more value to try
+                Some(new_val) => {
+                    self.value = CellValue::Filled(new_val);
+                    IncrementResult {
+                        is_board_valid: true,
+                        needs_revalidation: true,
+                    }
+                }
+            },
+            CellValue::Filled(val) => {
+                if val >= 9 {
+                    self.value = CellValue::Empty;
+                    IncrementResult {
+                        is_board_valid: false,
+                        needs_revalidation: false,
+                    }
+                } else {
+                    match self.get_next_not_constrained(val + 1) {
+                        // Can't be incremented, set to empty and tell the backtracker to find a new cell
+                        None => {
+                            self.value = CellValue::Empty;
+                            IncrementResult {
+                                is_board_valid: false,
+                                needs_revalidation: false,
+                            }
+                        }
+                        // There is at least 1 more value to try
+                        Some(new_val) => {
+                            self.value = CellValue::Filled(new_val);
+                            IncrementResult {
+                                is_board_valid: true,
+                                needs_revalidation: true,
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn get_next_not_constrained(&self, from: i8) -> Option<i8> {
+        // Clamp to the valid digit domain [1, 9]; short-circuit if above range.
+        let start = if from < 1 {
+            1
+        } else if from > 9 {
+            return None;
+        } else {
+            from
+        };
+        (start..=9)
+            .find(|&val| self.value_constraint_map[val as usize] == ValueConstraint::Allowed)
+    }}
+
+impl IsCell for ConstrainedCell {
+    fn value(&self) -> &CellValue {
+        &self.value
+    }
+
+    fn is_fixed(&self) -> bool {
+        self.fixed
+    }
+
+    fn init(value: CellValue, fixed: bool, position: CellPosition) -> Self {
+        ConstrainedCell {
+            value,
+            fixed,
+            position,
+            value_constraint_map: [ValueConstraint::Allowed; 10],
+        }
+    }
+}

--- a/src/board/cell/mod.rs
+++ b/src/board/cell/mod.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 
 pub mod simple_cell;
+pub mod constrained_cell;
 
 pub trait IsCell: Clone {
     fn value(&self) -> &CellValue;
@@ -19,7 +20,6 @@ pub enum CellValue {
     Filled(i8),
 }
 
-
 impl fmt::Display for CellValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", match self {
@@ -27,4 +27,9 @@ impl fmt::Display for CellValue {
             CellValue::Filled(val) => val.to_string()
         })
     }
+}
+
+pub struct IncrementResult {
+    pub is_board_valid: bool,
+    pub needs_revalidation: bool,
 }

--- a/src/board/cell/simple_cell.rs
+++ b/src/board/cell/simple_cell.rs
@@ -1,4 +1,4 @@
-use crate::board::cell::{CellPosition, CellValue, IsCell};
+use crate::board::cell::{CellPosition, CellValue, IncrementResult, IsCell};
 
 #[derive(Clone, Debug)]
 pub struct SimpleCell {
@@ -23,11 +23,6 @@ impl IsCell for SimpleCell {
             position
         }
     }
-}
-
-pub struct IncrementResult {
-    pub is_board_valid: bool,
-    pub needs_revalidation: bool,
 }
 
 impl SimpleCell {

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -6,7 +6,7 @@ pub mod cell;
 #[cfg(test)]
 mod tests;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Board<T>(pub [[T; 9]; 9])
 where
     T: IsCell;
@@ -149,24 +149,8 @@ where
         return Ok(board);
     }
 
-    fn check_puzzle_string_valid(puzzle: &str) -> Result<(), &'static str> {
-        if puzzle.len() != 81 {
-            return Err("Input string has the wrong length.");
-        }
-
-        if puzzle.find(|c: char| !char::is_numeric(c) && c != '.') != None {
-            return Err("Invalid char in input string.");
-        }
-
-        if puzzle.find(|c: char| c == '0') != None {
-            return Err("Found 0 in input string.");
-        }
-
-        return Ok(());
-    }
-
     // Checks if any group (9 cells) has any duplicates excluding 0s
-    fn is_group_correct(group: [&T; 9]) -> bool
+    pub fn is_group_correct(group: [&T; 9]) -> bool
     where
         T: IsCell,
     {
@@ -184,4 +168,14 @@ where
         }
         return true;
     }
-}
+    fn check_puzzle_string_valid(puzzle: &str) -> Result<(), &'static str> {
+        if puzzle.len() != 81 {
+            return Err("Input string has the wrong length.");
+        }
+
+        if !puzzle.chars().all(|c| c == '.' || (c.is_ascii_digit() && c != '0')) {
+            return Err("Invalid char in input string. Only '.' and ASCII digits 1-9 are allowed.");
+        }
+
+        return Ok(());
+    }}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn main() -> ExitCode {
     let puzzle =
         "8..45.6...3.68.......3.28.11.....2...6.....5...9.....89.78.6.......29.7...6.34..9";
     
-    let solver = match get_solver("backtracking") {
+    let solver = match get_solver("constrainedbacktracking") {
         Err(msg) => {
             println!("{}", msg);
             return ExitCode::FAILURE;

--- a/src/solvers/backtracking.rs
+++ b/src/solvers/backtracking.rs
@@ -1,4 +1,4 @@
-use crate::{board::{cell::{simple_cell::SimpleCell, CellPosition, CellValue}, Board}, solvers::Solver};
+use crate::{board::{cell::{simple_cell::SimpleCell, CellPosition}, Board}, solvers::Solver};
 
 pub struct BackTrackingSolver;
 impl Solver for BackTrackingSolver {
@@ -7,7 +7,7 @@ impl Solver for BackTrackingSolver {
             Err(error) => return Err(error),
             Ok(b) => b
         };
-        let mut curr_cell_pos: CellPosition = CellPosition { row: 0, column: 0 };
+        let mut curr_cell_pos: CellPosition;
         let mut is_valid = true;
         loop {
             // If the current board is valid (no duplicate values)
@@ -42,9 +42,5 @@ impl Solver for BackTrackingSolver {
                 is_valid = increment_result.is_board_valid;
             }
         }
-    }
-    
-    fn name(&self) -> &'static str {
-        "Backtracking"
     }
 }

--- a/src/solvers/constrained_backtracking.rs
+++ b/src/solvers/constrained_backtracking.rs
@@ -1,0 +1,134 @@
+use crate::{
+    board::{
+        Board,
+        cell::{
+            CellPosition, CellValue,
+            constrained_cell::{ConstrainedCell, ValueConstraint},
+        },
+    },
+    solvers::Solver,
+};
+pub struct ConstrainedBackTrackingSolver;
+
+impl Solver for ConstrainedBackTrackingSolver {
+    fn solve(&self, puzzle: &'static str) -> Result<(bool, String), &'static str> {
+        let mut board = match Board::<ConstrainedCell>::parse_puzzle_string(puzzle) {
+            Err(error) => return Err(error),
+            Ok(b) => b,
+        };
+
+        ConstrainedBackTrackingSolver::calculate_fixed_board_constrains_until_stable(&mut board);
+
+        let mut curr_cell_pos: CellPosition;
+        let mut is_valid = true;
+        loop {
+            // If the current board is valid (no duplicate values)
+            curr_cell_pos = if is_valid {
+                if let Some(cell) = board.get_first_non_fixed_zero() {
+                    cell.position.clone()
+                } else {
+                    if board.is_correct() {
+                        return Ok((true, board.to_str().clone()));
+                    } else {
+                        if let Some(cell) = board.get_last_non_fixed_non_zero() {
+                            cell.position.clone()
+                        } else {
+                            return Ok((false, "".to_string()));
+                        }
+                    }
+                }
+            } else {
+                if let Some(cell) = board.get_last_non_fixed_non_zero() {
+                    cell.position.clone()
+                } else {
+                    return Ok((false, "".to_string()));
+                }
+            };
+
+            let mut_cell = board.get_mut_cell(&curr_cell_pos);
+            let increment_result = mut_cell.increment();
+
+            if increment_result.needs_revalidation {
+                is_valid = board.is_cell_valid(curr_cell_pos);
+            } else {
+                is_valid = increment_result.is_board_valid;
+            }
+        }
+    }
+}
+
+impl ConstrainedBackTrackingSolver {
+    fn calculate_fixed_board_constrains_until_stable(board: &mut Board<ConstrainedCell>) {
+        while ConstrainedBackTrackingSolver::calculate_fixed_board_constrains(board) {}
+    }
+    fn calculate_fixed_board_constrains(board: &mut Board<ConstrainedCell>) -> bool {
+        let mut changed = false;
+        let starting_board = &*board;
+        let mut forbidden_map: [[[bool;10]; 9]; 9] = [[[false; 10]; 9]; 9];
+        for row in &board.0 {
+            for cell in row {
+                if !cell.fixed {
+                    let position = cell.position;
+                    // Boolean array: forbidden[i] = true if value i is not allowed
+                    let mut forbidden = [false; 10];
+
+                    // Mark row constraints
+                    for c in starting_board.get_row(position.row) {
+                        if c.position.column != position.column {
+                            if let CellValue::Filled(val) = c.value {
+                                forbidden[val as usize] = true;
+                            }
+                        }
+                    }
+
+                    // Mark column constraints
+                    for c in starting_board.get_col(position.column) {
+                        if c.position.row != position.row {
+                            if let CellValue::Filled(val) = c.value {
+                                forbidden[val as usize] = true;
+                            }
+                        }
+                    }
+                    // Mark square constraints
+                    for c in starting_board.get_square(position.column, position.row) {
+                        if c.position != position {
+                            if let CellValue::Filled(val) = c.value {
+                                forbidden[val as usize] = true;
+                            }
+                        }
+                    }
+                    forbidden_map[cell.position.row as usize][cell.position.column as usize] = forbidden;
+                }
+            }
+        }
+        for row in &mut board.0 {
+                 for cell in row {
+                    let position = cell.position;
+                    let forbidden = forbidden_map[position.row as usize][position.column as usize];
+
+                    let mut allowed_val = None;
+                    let mut only_one = true;
+                    for i in 1..=9 {
+                        if forbidden[i as usize] && cell.value_constraint_map[i as usize] == ValueConstraint::Allowed {
+                            cell.value_constraint_map[i as usize] = ValueConstraint::FixedNotAllowed;
+                            changed = true;
+                        }
+                        if only_one && cell.value_constraint_map[i as usize] == ValueConstraint::Allowed {
+                            if allowed_val.is_some() {
+                                only_one = false;
+                            }
+                            allowed_val = Some(i);
+                        }
+                    }
+
+                    if only_one {
+                        if let Some(val) = allowed_val {
+                            cell.fixed = true;
+                            cell.value = CellValue::Filled(val as i8);
+                        }
+                    }
+                }
+        }
+        changed
+    }
+}

--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -1,13 +1,17 @@
-use crate::solvers::{backtracking::BackTrackingSolver};
+use crate::solvers::{backtracking::BackTrackingSolver, constrained_backtracking::ConstrainedBackTrackingSolver};
 
 #[cfg(test)]
 mod tests;
 
 
 pub mod backtracking;
+pub mod constrained_backtracking;
 
 pub trait Solver {
-    fn name(&self) -> &'static str;
+    #[allow(dead_code)]
+    fn name(&self) -> &'static str {
+        std::any::type_name::<Self>()
+    }
     fn solve(&self, board: &'static str) -> Result<(bool, String), &'static str>;
 }
 
@@ -15,6 +19,7 @@ pub trait Solver {
 pub fn get_solver(s: &str) -> Result<Box<dyn Solver>, String> {
     match s.to_lowercase().as_str() {
         "backtracking" => Ok(Box::new(BackTrackingSolver)),
+        "constrainedbacktracking" => Ok(Box::new(ConstrainedBackTrackingSolver)),
         _ => Err("Unknown solver type: ".to_owned() + s)
      }
 }

--- a/src/solvers/tests.rs
+++ b/src/solvers/tests.rs
@@ -1,8 +1,9 @@
-use crate::{solvers::{BackTrackingSolver, Solver}};
+use crate::solvers::{constrained_backtracking::ConstrainedBackTrackingSolver, BackTrackingSolver, Solver};
 
 
 fn check_all_solvers(puzzle: &'static str, solution: Option<&'static str>) {
     check_solver(BackTrackingSolver,puzzle, solution);
+    check_solver(ConstrainedBackTrackingSolver,puzzle, solution);
 }
 
 fn check_solver<S: Solver>(solver: S, board: &'static str, expect: Option<&'static str>) {


### PR DESCRIPTION
This solver does an initial few passes (exact count depends on the puzzle). Each pass keeps track of the values a cell can take and stores them in the cell. This reduces the search space by elliminating any values that would be obviously wrong based on the fixed cells.

If any cell only has 1 possible value, it is fixed. The rest of the implementation is similar to the simple backtracker, with the only change being that the cell increment skips any values that are invalid.