### PR TITLE
make calculate_fixed_board_constrains quicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,10 @@ A full historical list of bench mark results can be found at [bench_results.md](
 ### Latest
 Name | [fastest, median, slowest]
 --- | --- 
-Backtracking_simple | [0.61103 ms 0.61214 ms 0.61343 ms]
-Backtracking_hard | [1844.7 ms 1854.6 ms 1864.9 ms]
-ConstrainedBackTrackingSolver_simple | [0.20164 ms 0.20315 ms 0.20513]
-ConstrainedBackTrackingSolver_hard | [1041.0 ms 1048.3 ms 1057.2 ms]
-
+Backtracking_simple | [0.62312 ms 0.62718 ms 0.63191 ms]
+Backtracking_hard | [1948.5 ms 1974.3 ms 2000.0 ms]
+ConstrainedBackTrackingSolver_simple | [0.19662 ms 0.20070 ms 0.20518 ms]
+ConstrainedBackTrackingSolver_hard | [1105.7 ms 1114.6 ms 1123.9 ms]
 
 ### Usage
 ```bash

--- a/benches/bench_results.md
+++ b/benches/bench_results.md
@@ -1,3 +1,9 @@
+### 2025-08-20
+- **Backtracking_simple**: [0.62312 ms 0.62718 ms 0.63191 ms]
+- **Backtracking_hard**: [1948.5 ms 1974.3 ms 2000.0 ms]
+- **ConstrainedBackTrackingSolver_simple**: [0.19662 ms 0.20070 ms 0.20518 ms]
+- **ConstrainedBackTrackingSolver_hard**: [1105.7 ms 1114.6 ms 1123.9 ms]
+
 ### 2025-08-19
 - **Backtracking_simple**: [0.61103 ms 0.61214 ms 0.61343 ms]
 - **Backtracking_hard**: [1844.7 ms 1854.6 ms 1864.9 ms]

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -35,7 +35,6 @@ where
 
     pub fn get_square(&self, x: i8, y: i8) -> [&T; 9] {
         let x_in_square = x % 3;
-
         let y_in_square = y % 3;
 
         let square_corner_x = x - x_in_square;


### PR DESCRIPTION
This is done by removing duplicate checks and using bitwise operations instead of arrays of booleans.